### PR TITLE
locked to ansible branch 2.9-stable

### DIFF
--- a/install_ansible.sh
+++ b/install_ansible.sh
@@ -7,7 +7,7 @@ mkdir -p $HOME/ansible_env
 cd $HOME/ansible_env
 virtualenv ansible
 source $HOME/ansible_env/ansible/bin/activate 
-git clone https://github.com/ansible/ansible.git --recursive ./ansible_source
+git clone --single-branch --branch stable-2.9 https://github.com/ansible/ansible.git --recursive ./ansible_source
 #pexpect has to be 3.3 because new 4.01 version only
 # works with python >= 2.7 :(
 pip install paramiko PyYAML Jinja2 httplib2 six pexpect==3.3


### PR DESCRIPTION
locked to a branch that still contains the nmcli module by default, as
the devel branch is in the midst of migrating.

Signed-off-by: Eric Coulter <jecoulte@iu.edu>